### PR TITLE
feat(protocol): implement reference image replication protocol and validation scripts

### DIFF
--- a/skills/drawio-diagram-builder/SKILL.md
+++ b/skills/drawio-diagram-builder/SKILL.md
@@ -34,7 +34,11 @@ Use this priority order:
 4. **draw.io MCP / `@drawio/mcp`** — only for small diagrams or quick opening. On Windows, large encoded URLs fail with `The data area passed to a system call is too small`; do not rely on `.url` shortcuts for large XML.
 5. **draw.io desktop/CLI export** — if installed. Treat as optional; always have the local iframe preview fallback.
 
-Load `references/drawio-workflow.md` for the detailed end-to-end process. Load `references/xml-authoring.md` when writing or repairing XML shapes, styles, edges, and text layout. Resolve both relative to the skill directory.
+Load `references/drawio-workflow.md` for the detailed end-to-end process. Load `references/xml-authoring.md` when writing or repairing XML shapes, styles, edges, and text layout.
+
+For any reference-image replication request, load `references/reference-replication-protocol.md` before creating XML. This is mandatory. Do not start drawing from a reference image until the protocol's required intermediate artifacts exist.
+
+Resolve all references relative to the skill directory.
 
 ## Standard Workflow
 
@@ -50,8 +54,14 @@ Load `references/drawio-workflow.md` for the detailed end-to-end process. Load `
    - For reference-image replication, create a coordinate-level inventory: bounding boxes, text lines, highlight bars, connectors, loops, and repeated blocks.
    - For paper figures, preserve exact method terminology and distinguish data construction, training, evaluation, inference, and serving flows.
    - Decide what must be exact and what can be approximated.
+   - For reference-image replication, write the required protocol artifacts before XML:
+     - `visual-spec.md`
+     - `layout-grid.md`
+     - `asset-ledger.md`
+     - `defect-log.md`
 
 4. **Author the `.drawio` file**
+   - The `.drawio` file is the primary artifact. Preview HTML is only a derived artifact.
    - Use one `mxfile` with one or more `diagram` pages.
    - Use explicit `mxGeometry` positions and sizes for high-fidelity work.
    - Split dense text into multiple cells when line-level alignment matters.
@@ -70,6 +80,7 @@ Load `references/drawio-workflow.md` for the detailed end-to-end process. Load `
    - Fix a small batch of concrete issues per pass: text overflow, a bad arrow, one misaligned block, wrong color, incorrect icon, spacing, or missing component.
    - Regenerate the preview HTML, refresh the browser (add a cache-busting `?rev=N`), screenshot again, and repeat.
    - Name the specific defects being fixed rather than claiming broad perfection.
+   - For reference-image replication, append every screenshot pass to `defect-log.md` with: observed defect, reference evidence, XML cells to change, patch summary, and remaining risk.
 
 7. **Validate before handoff**
    - Run `scripts/validate_drawio.py <file>.drawio`.
@@ -83,6 +94,7 @@ Load `references/drawio-workflow.md` for the detailed end-to-end process. Load `
 - Keep a working copy and a handoff copy only when useful; keep them synchronized.
 - Never claim the diagram is complete without visual verification (a screenshot).
 - When the user asks for "100% reproduction", treat that as an iterative standard: keep finding and fixing visible differences until the user accepts or identifies next issues.
+- For reference-image replication, never skip the intermediate artifacts. A low-quality first draw usually means the visual-spec and layout-grid were too vague.
 
 ## Common Failure Handling
 
@@ -103,4 +115,5 @@ Load `references/drawio-workflow.md` for the detailed end-to-end process. Load `
 - `scripts/serve_drawio_preview.py`: generate the preview HTML and serve it on `127.0.0.1` with an optional browser launch.
 - `scripts/validate_drawio.py`: parse and sanity-check `.drawio` files before handoff.
 - `references/drawio-workflow.md`: full professional workflow for prompt/paper/code/reference-image to editable draw.io.
+- `references/reference-replication-protocol.md`: low-freedom protocol for high-fidelity reference-image replication.
 - `references/xml-authoring.md`: XML, layout, style, edge, text, icon, and iteration patterns.

--- a/skills/drawio-diagram-builder/references/reference-replication-protocol.md
+++ b/skills/drawio-diagram-builder/references/reference-replication-protocol.md
@@ -1,0 +1,181 @@
+# Reference Image Replication Protocol
+
+Use this protocol whenever the user provides a reference image and asks to reproduce, redraw, copy, replicate, or closely match it in draw.io.
+
+The goal is to stop the agent from guessing. The agent must first convert the image into a mechanical visual specification, then draw from that specification, then verify with screenshots.
+
+## Hard Rules
+
+1. Do not begin `.drawio` XML until the required intermediate artifacts exist.
+2. The primary output is a `.drawio` file. Preview HTML is derived and must not be treated as the source of truth.
+3. Never silently omit a visible component. If an icon, formula, symbol, or image cannot be reproduced exactly, add it to `asset-ledger.md`.
+4. Do not use "close enough" language for high-fidelity work. Record remaining mismatches in `defect-log.md`.
+5. Do not finish without at least one rendered screenshot review. For 100% reproduction requests, keep iterating until the user accepts or the remaining gaps are explicitly listed.
+
+## Required Artifacts
+
+Create these files next to the working `.drawio` file:
+
+```text
+visual-spec.md
+layout-grid.md
+asset-ledger.md
+defect-log.md
+```
+
+Run `scripts/validate_replication_artifacts.py <workdir>` before authoring XML and again before handoff.
+
+## 1. visual-spec.md
+
+This file captures what is visible.
+
+Required sections:
+
+```markdown
+# Visual Spec
+
+## Source
+- Reference image:
+- Target drawio:
+- Canvas:
+- Font policy:
+
+## Global Style
+- Background:
+- Primary font:
+- Stroke style:
+- Arrow style:
+- Color palette:
+
+## Regions
+| id | bbox x,y,w,h | role | visual notes |
+
+## Text Blocks
+| id | bbox x,y,w,h | text | font | alignment | priority |
+
+## Shapes
+| id | bbox x,y,w,h | type | fill | stroke | notes |
+
+## Connectors
+| id | from | to | route | arrowheads | label | notes |
+
+## Icons And Images
+| id | bbox x,y,w,h | meaning | exact/approx/missing | replacement plan |
+```
+
+For complex research figures, use region IDs such as:
+
+- `top_problem_statement`
+- `bottom_method_overview`
+- `memory_hierarchy`
+- `routing_controller`
+- `latent_workspace`
+- `multimodal_streams`
+
+## 2. layout-grid.md
+
+This file turns the visual spec into coordinates. Weak models need hard numbers.
+
+Required sections:
+
+```markdown
+# Layout Grid
+
+## Canvas
+- width:
+- height:
+- scale assumption:
+- margin:
+
+## Grid Lines
+| name | x | y | purpose |
+
+## Region Boxes
+| id | x | y | w | h |
+
+## Repeated Components
+| family | count | cell size | spacing | start x,y |
+
+## Drawing Order
+1. background regions
+2. containers
+3. internal shapes
+4. connectors
+5. text
+6. icons
+7. highlights/overlays
+```
+
+If the reference has a dense layout, do not rely on relative placement only. Use explicit x/y/w/h for each major container.
+
+## 3. asset-ledger.md
+
+This file prevents silent icon loss.
+
+Required sections:
+
+```markdown
+# Asset Ledger
+
+## Exact Assets
+| id | source | path | usage |
+
+## Editable Primitive Icons
+| id | built from | fidelity notes |
+
+## Approximations
+| id | reference meaning | approximation | why |
+
+## Missing Assets
+| id | reference meaning | blocking issue | user action needed |
+```
+
+If using an embedded raster image, state why editability is intentionally reduced.
+
+## 4. defect-log.md
+
+This file records screenshot-based refinement.
+
+Required sections:
+
+```markdown
+# Defect Log
+
+## Pass 0 - Initial Plan Review
+| issue | reference evidence | planned fix |
+
+## Pass 1 - Screenshot Review
+| issue | observed screenshot | reference evidence | XML cells to change | patch summary | status |
+
+## Remaining Gaps
+| gap | severity | reason | next action |
+```
+
+Each screenshot pass must add concrete defects. Avoid entries like "looks bad"; write "right-side multimodal panel is 18% too narrow" or "top dense-token bar missing icon cells".
+
+## Minimum Quality Gate
+
+Before handoff, verify:
+
+- The `.drawio` file exists and is the primary artifact.
+- `validate_drawio.py` passes.
+- `validate_replication_artifacts.py` passes.
+- Preview HTML was regenerated after the latest XML edit.
+- At least one screenshot was reviewed.
+- `defect-log.md` lists remaining mismatches.
+- No visible reference component was silently omitted.
+
+## Guidance For Weak Spatial Models
+
+If the model produces a messy first draft, do not continue patching randomly. Return to `layout-grid.md` and make the coordinate plan more explicit.
+
+Prefer a simpler but structurally faithful first draft over a visually dense but incoherent drawing:
+
+1. Correct canvas and major regions.
+2. Correct container hierarchy.
+3. Correct text placement.
+4. Correct arrows.
+5. Correct icons.
+6. Correct colors and polish.
+
+Only after the structure is correct should the agent increase visual density.

--- a/skills/drawio-diagram-builder/scripts/validate_replication_artifacts.py
+++ b/skills/drawio-diagram-builder/scripts/validate_replication_artifacts.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Validate required intermediate files for reference-image replication."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+REQUIRED = {
+    "visual-spec.md": [
+        "# Visual Spec",
+        "## Source",
+        "## Global Style",
+        "## Regions",
+        "## Text Blocks",
+        "## Shapes",
+        "## Connectors",
+        "## Icons And Images",
+    ],
+    "layout-grid.md": [
+        "# Layout Grid",
+        "## Canvas",
+        "## Grid Lines",
+        "## Region Boxes",
+        "## Repeated Components",
+        "## Drawing Order",
+    ],
+    "asset-ledger.md": [
+        "# Asset Ledger",
+        "## Exact Assets",
+        "## Editable Primitive Icons",
+        "## Approximations",
+        "## Missing Assets",
+    ],
+    "defect-log.md": [
+        "# Defect Log",
+        "## Pass 0 - Initial Plan Review",
+        "## Pass 1 - Screenshot Review",
+        "## Remaining Gaps",
+    ],
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check reference-image replication planning artifacts."
+    )
+    parser.add_argument("workdir", type=Path, help="Directory containing visual-spec/layout-grid/asset-ledger/defect-log.")
+    args = parser.parse_args()
+
+    workdir = args.workdir.resolve()
+    errors: list[str] = []
+
+    if not workdir.exists():
+        print(f"ERROR: missing directory: {workdir}", file=sys.stderr)
+        return 2
+
+    for filename, headings in REQUIRED.items():
+        path = workdir / filename
+        if not path.exists():
+            errors.append(f"missing {filename}")
+            continue
+        text = path.read_text(encoding="utf-8")
+        if len(text.strip()) < 80:
+            errors.append(f"{filename} is too short to be useful")
+        for heading in headings:
+            if heading not in text:
+                errors.append(f"{filename} missing heading: {heading}")
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print(f"replication artifacts OK: {workdir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/replication-artifacts/asset-ledger.md
+++ b/tests/fixtures/replication-artifacts/asset-ledger.md
@@ -1,0 +1,17 @@
+# Asset Ledger
+
+## Exact Assets
+| id | source | path | usage |
+| none | n/a | n/a | n/a |
+
+## Editable Primitive Icons
+| id | built from | fidelity notes |
+| icon1 | rectangles | sample |
+
+## Approximations
+| id | reference meaning | approximation | why |
+| none | n/a | n/a | n/a |
+
+## Missing Assets
+| id | reference meaning | blocking issue | user action needed |
+| none | n/a | n/a | n/a |

--- a/tests/fixtures/replication-artifacts/defect-log.md
+++ b/tests/fixtures/replication-artifacts/defect-log.md
@@ -1,0 +1,13 @@
+# Defect Log
+
+## Pass 0 - Initial Plan Review
+| issue | reference evidence | planned fix |
+| none | smoke fixture | none |
+
+## Pass 1 - Screenshot Review
+| issue | observed screenshot | reference evidence | XML cells to change | patch summary | status |
+| none | smoke fixture | smoke fixture | n/a | n/a | closed |
+
+## Remaining Gaps
+| gap | severity | reason | next action |
+| none | low | smoke fixture | none |

--- a/tests/fixtures/replication-artifacts/layout-grid.md
+++ b/tests/fixtures/replication-artifacts/layout-grid.md
@@ -1,0 +1,28 @@
+# Layout Grid
+
+## Canvas
+- width: 800
+- height: 600
+- scale assumption: 1:1
+- margin: 40
+
+## Grid Lines
+| name | x | y | purpose |
+| left | 40 | | margin |
+
+## Region Boxes
+| id | x | y | w | h |
+| main | 40 | 40 | 720 | 520 |
+
+## Repeated Components
+| family | count | cell size | spacing | start x,y |
+| sample | 2 | 100x40 | 20 | 100,100 |
+
+## Drawing Order
+1. background regions
+2. containers
+3. internal shapes
+4. connectors
+5. text
+6. icons
+7. highlights/overlays

--- a/tests/fixtures/replication-artifacts/visual-spec.md
+++ b/tests/fixtures/replication-artifacts/visual-spec.md
@@ -1,0 +1,34 @@
+# Visual Spec
+
+## Source
+- Reference image: smoke-test.png
+- Target drawio: smoke-test.drawio
+- Canvas: 800 x 600
+- Font policy: use source font when specified
+
+## Global Style
+- Background: white
+- Primary font: Arial
+- Stroke style: rounded rectangles
+- Arrow style: classic arrows
+- Color palette: gray, blue
+
+## Regions
+| id | bbox x,y,w,h | role | visual notes |
+| main | 40,40,720,520 | sample | one central region |
+
+## Text Blocks
+| id | bbox x,y,w,h | text | font | alignment | priority |
+| title | 60,60,200,40 | Smoke | Arial | left | high |
+
+## Shapes
+| id | bbox x,y,w,h | type | fill | stroke | notes |
+| box | 100,100,200,80 | rounded | #ffffff | #666666 | sample |
+
+## Connectors
+| id | from | to | route | arrowheads | label | notes |
+| e1 | a | b | straight | end | | sample |
+
+## Icons And Images
+| id | bbox x,y,w,h | meaning | exact/approx/missing | replacement plan |
+| icon1 | 0,0,0,0 | none | missing | not needed |

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -21,6 +21,8 @@ def run(command: list[str]) -> None:
 
 def main() -> int:
     run([sys.executable, str(SKILL / "scripts" / "validate_drawio.py"), str(EXAMPLE)])
+    protocol_dir = ROOT / "tests" / "fixtures" / "replication-artifacts"
+    run([sys.executable, str(SKILL / "scripts" / "validate_replication_artifacts.py"), str(protocol_dir)])
     run(
         [
             sys.executable,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a strict reference-image replication protocol with required planning artifacts and a validator to enforce them. Improves fidelity for `.drawio` reproductions and integrates the checks into the smoke test.

- New Features
  - Added `references/reference-replication-protocol.md` defining a low-freedom workflow and four required artifacts: `visual-spec.md`, `layout-grid.md`, `asset-ledger.md`, `defect-log.md`.
  - Added `scripts/validate_replication_artifacts.py` to verify artifact presence, key headings, and basic length; run as `validate_replication_artifacts.py <workdir>`.
  - Updated `SKILL.md` to mandate the protocol, require artifacts before XML, and to log each screenshot pass in `defect-log.md`.
  - Added fixtures for the four artifacts and updated `tests/smoke_test.py` to run the new validator.

- Migration
  - For any reference-image replication, create the four artifacts alongside the working `.drawio`.
  - Run `scripts/validate_replication_artifacts.py` before authoring XML and again before handoff (add to local workflow/CI).

<sup>Written for commit dca2d70b2780a0af69248550440661f3c207631d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Will-hxw/drawio-diagram-builder-skill/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

